### PR TITLE
Fix missing schedule tab on frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,9 +4,10 @@ import Picks from '@components/Picks'
 import Standings from '@components/Standings'
 import Dashboard from '@components/Dashboard'
 import Admin from '@components/Admin'
+import Schedule from '@components/Schedule'
 import { useState } from 'react'
 
-type Tab = 'dashboard' | 'picks' | 'participants' | 'standings' | 'admin'
+type Tab = 'dashboard' | 'schedule' | 'picks' | 'participants' | 'standings' | 'admin'
 
 export default function App() {
   const [tab, setTab] = useState<Tab>('dashboard')
@@ -24,12 +25,14 @@ export default function App() {
       </div>
       <nav className="tab-nav">
         <button className={tab==='dashboard' ? 'active' : ''} onClick={() => setTab('dashboard')}>Dashboard</button>
+        <button className={tab==='schedule' ? 'active' : ''} onClick={() => setTab('schedule')}>Schedule</button>
         <button className={tab==='picks' ? 'active' : ''} onClick={() => setTab('picks')}>Picks</button>
         <button className={tab==='participants' ? 'active' : ''} onClick={() => setTab('participants')}>Participants</button>
         <button className={tab==='standings' ? 'active' : ''} onClick={() => setTab('standings')}>Standings</button>
         <button className={tab==='admin' ? 'active' : ''} onClick={() => setTab('admin')}>Admin</button>
       </nav>
       {tab === 'dashboard' && <Dashboard />}
+      {tab === 'schedule' && <Schedule />}
       {tab === 'picks' && <Picks />}
       {tab === 'participants' && <Participants />}
       {tab === 'standings' && <Standings />}

--- a/frontend/src/components/Schedule.tsx
+++ b/frontend/src/components/Schedule.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from 'react';
+import { api, type Game } from '@api/client';
+
+export default function Schedule() {
+  const [season, setSeason] = useState('20252026');
+  const [games, setGames] = useState<Game[]>([]);
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      setGames(await api.listGames());
+    } catch (e:any) {
+      setError(e.message);
+    }
+  };
+
+  useEffect(() => { refresh(); }, []);
+
+  const importSeason = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setImporting(true);
+    try {
+      await api.importSeason(season.trim());
+      await refresh();
+    } catch (e:any) {
+      setError(e.message);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const grouped = useMemo(() => {
+    const bySeason: Record<string, Game[]> = {};
+    for (const g of games) {
+      if (!bySeason[g.season]) bySeason[g.season] = [];
+      bySeason[g.season].push(g);
+    }
+    for (const s of Object.keys(bySeason)) {
+      bySeason[s].sort((a,b)=>a.date.localeCompare(b.date));
+    }
+    return bySeason;
+  }, [games]);
+
+  return (
+    <div>
+      <h2>Schedule</h2>
+      <form onSubmit={importSeason} style={{ display:'flex', gap:8, justifyContent:'center', marginBottom:12 }}>
+        <input value={season} onChange={e=>setSeason(e.target.value)} placeholder="Season (e.g., 20252026)" />
+        <button type="submit" disabled={importing || !/^\d{8}$/.test(season)}>{importing ? 'Importing...' : 'Import Season'}</button>
+        <button type="button" onClick={refresh}>Refresh</button>
+      </form>
+      {error && <div style={{ color:'red', marginBottom:8 }}>{error}</div>}
+      {Object.keys(grouped).length === 0 && <div>No games found. Import a season.</div>}
+      {Object.entries(grouped).sort((a,b)=>a[0].localeCompare(b[0])).map(([s, arr]) => (
+        <div key={s} style={{ marginBottom:16 }}>
+          <h3>Season {s}</h3>
+          <table style={{ width:'100%' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign:'left' }}>Date</th>
+                <th style={{ textAlign:'left' }}>Opponent</th>
+                <th style={{ textAlign:'left' }}>Home/Away</th>
+                <th style={{ textAlign:'left' }}>Status</th>
+                <th style={{ textAlign:'left' }}>Double</th>
+              </tr>
+            </thead>
+            <tbody>
+              {arr.map(g => (
+                <tr key={g.id}>
+                  <td>{new Date(g.date).toLocaleString()}</td>
+                  <td>{g.opponent}</td>
+                  <td>{g.home ? 'Home' : 'Away'}</td>
+                  <td>{g.status}</td>
+                  <td>{g.double_points ? 'Yes' : ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
Add a Schedule tab and component to the frontend to enable importing and viewing season schedules.

---
<a href="https://cursor.com/background-agent?bcId=bc-9249a63e-1863-4935-8a26-a424b318ca62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9249a63e-1863-4935-8a26-a424b318ca62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

